### PR TITLE
implemented user media pages(movies, tvshows, books, music)

### DIFF
--- a/onemed1a-frontend/jsconfig.json
+++ b/onemed1a-frontend/jsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/onemed1a-frontend/package-lock.json
+++ b/onemed1a-frontend/package-lock.json
@@ -1213,6 +1213,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.11.tgz",

--- a/onemed1a-frontend/src/app/[mediaType]/page.js
+++ b/onemed1a-frontend/src/app/[mediaType]/page.js
@@ -1,0 +1,44 @@
+import MediaNav from "@/components/MediaNavigation";
+import MediaGrid from "@/components/MediaGrid";
+import PropTypes from "prop-types";
+
+const mediaData = {
+  movies: [
+    { id: 1, title: "Inception", coverUrl: "/next.svg", year: 2010 },
+    { id: 2, title: "Interstellar", coverUrl: "/next.svg", year: 2014 },
+  ],
+  tvshows: [
+    { id: 1, title: "Breaking Bad", coverUrl: "/next.svg", year: 2008 },
+    { id: 2, title: "Dark", coverUrl: "/next.svg", year: 2017 },
+  ],
+  music: [
+  { id: 1, title: 'Abbey Road', coverUrl: '/next.svg', year: 1969 },
+  { id: 2, title: 'Dark Side of the Moon', coverUrl: '/next.svg', year: 1973 },
+  { id: 3, title: 'Thriller', coverUrl: '/next.svg', year: 1982 },
+  ],
+  books: [
+  { id: 1, title: '1984', coverUrl: '/next.svg', year: 1949 },
+  { id: 2, title: 'Brave New World', coverUrl: '/next.svg', year: 1932 },
+  { id: 3, title: 'Fahrenheit 451', coverUrl: '/next.svg', year: 1953 },
+  ],
+};
+
+
+export default function MediaPage({ params }) {
+  const { mediaType } = params;
+  const items = mediaData[mediaType] || [];
+
+  return (
+    <div className="p-4">
+      <MediaNav />
+      <h1 className="text-2xl font-bold my-4">{mediaType.toUpperCase()}</h1>
+      <MediaGrid items={items} />
+    </div>
+  );
+}
+
+MediaPage.propTypes = {
+  params: PropTypes.shape({
+    mediaType: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/onemed1a-frontend/src/components/MediaGrid.js
+++ b/onemed1a-frontend/src/components/MediaGrid.js
@@ -1,0 +1,37 @@
+import Image from "next/image";
+import PropTypes from "prop-types";
+
+export default function MediaGrid({ items }) {
+  if (!items.length) return <p>No items yet.</p>;
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+      {items.map((item) => (
+        <div
+          key={item.id}
+          className="p-2 bg-gray-100 rounded hover:shadow-lg transition"
+        >
+          <Image
+            src={item.coverUrl || "/placeholder.png"}
+            alt={item.title}
+            width={150}
+            height={200}
+          />
+          <h3 className="text-sm font-bold mt-2">{item.title}</h3>
+          <p className="text-xs">{item.year}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+MediaGrid.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      coverUrl: PropTypes.string,
+      title: PropTypes.string.isRequired,
+      year: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    })
+  ).isRequired,
+};

--- a/onemed1a-frontend/src/components/MediaNavigation.js
+++ b/onemed1a-frontend/src/components/MediaNavigation.js
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+export default function MediaNav() {
+  const tabs = [
+    { name: "Movies", href: "/movies" },
+    { name: "TV Shows", href: "/tvshows" },
+    { name: "Books", href: "/books" },
+    { name: "Music", href: "/music" },
+  ];
+
+  return (
+    <nav className="flex gap-4 bg-gray-100 p-4 rounded">
+      {tabs.map((tab) => (
+        <Link
+          key={tab.name}
+          href={tab.href}
+          className="px-3 py-1 rounded hover:bg-gray-300 transition font-medium"
+        >
+          {tab.name}
+        </Link>
+      ))}
+    </nav>
+  );
+}


### PR DESCRIPTION
Added separate media pages for Movies, TV Shows, Books, and Music.

- Implemented routes: /movies, /tvshows, /books, /music
- All four pages use the shared template in src/components/MediaGrid.js for consistent styling and layout

This work addresses issue #13