### PR TITLE
Fixed bug with CORS where it only allows from localhost:3000

### DIFF
--- a/onemed1a-backend/src/main/java/com/onemed1a/backend/config/AppConfig.java
+++ b/onemed1a-backend/src/main/java/com/onemed1a/backend/config/AppConfig.java
@@ -31,7 +31,7 @@ public class AppConfig {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration cfg = new CorsConfiguration();
-        cfg.setAllowedOriginPatterns(List.of("http://localhost:3000")); 
+        cfg.setAllowedOriginPatterns(List.of("*")); 
         cfg.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         cfg.setAllowedHeaders(List.of("*"));
         cfg.setAllowCredentials(true); 


### PR DESCRIPTION
Fixed a bug where the CORS only allows calls from localhost:3000, now it can accept calls from every url.

This addresses issue #49.