### PR TITLE
Configured SonarCloud to work on the frontend

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,19 @@
+name: Build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarqube:
+    name: SonarQube
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=softeng-310-onemed1a-1_one-media
+sonar.organization=softeng-310-onemed1a-1
+
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=One-Media
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
This PR adds a `build.yaml` GitHub Actions workflow to run SonarCloud analysis for the frontend and a `sonar-project.properties` file to configure the project name/key (and related settings). With this, frontend PRs will receive SonarCloud checks and quality gate feedback.

This pull request closes #58.
