### PR TITLE
Restrict sonar job to main branch pushes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,12 +1,13 @@
 name: CI & SonarCloud
+
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    types: [opened, synchronize, reopened]
+    branches: [ main ]   # only run on main pushes
 
 jobs:
   sonar:
+    # extra safety: ensure it's a push to main
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Change the SonarCloud build file, so it doesn't scan on PR branches just the main branch. 