### PR TITLE
Adding a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Description of changes
+
+A clear description of what changes have been made
+
+## Linked issue(s)
+
+Closes #123
+
+## Checklist
+
+- [ ] I rebased onto `upstream/main` before pushing
+- [ ] No secrets or .env files committed


### PR DESCRIPTION
## Description of changes 
Added a PR template that automatically populates when contributors open a pull request

## Linked issue(s)
Closes #88 

## Checklist
 - [X] I rebased onto upstream/main before pushing
 - [X] No secrets or .env files committed