### PR TITLE
fix: await params before accessing mediaType to resolve Next.js dynamic route error

### DIFF
--- a/onemed1a-frontend/src/app/[mediaType]/page.js
+++ b/onemed1a-frontend/src/app/[mediaType]/page.js
@@ -56,7 +56,7 @@ function pickCover(
  * @param {{ params: { id: string } }} props
  */
 export default async function MediaPage({ params }) {
-  const { mediaType: rawMediaType } = params;
+  const { mediaType: rawMediaType } = await params;
   const mediaTypeKey = normalizeTypeKey(rawMediaType);
   const wantedType = typeMap[mediaTypeKey];
 


### PR DESCRIPTION
… error

## Description of changes
This pull request fixes the runtime error in the dynamic route /[mediaType] caused by accessing params.mediaType synchronously in an async page component.
- Updated `src/app/[mediaType]/page.js` to `await params` before destructuring `mediaType`.
- Verified that all dynamic routes (/movie, /tv, /books, /music) render correctly without console errors.

## Linked issue(s)

Closes #103 

## Checklist

- [x] I rebased onto `upstream/main` before pushing
- [x] No secrets or .env files committed
