### PR TITLE
feat/sonar setup

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,67 @@
+name: SonarCloud Scan
+
+on:
+  push:
+    branches: [ main, feat/*, fix/* ]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build backend (Maven)
+        working-directory: onemed1a-backend
+        run: mvn -B -V -DskipTests=false verify
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install frontend dependencies
+        working-directory: onemed1a-frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: onemed1a-frontend
+        run: npm run build --if-present
+
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >-
+            -Dsonar.projectKey=softeng-310-onemed1a-1_one-media
+            -Dsonar.organization=softeng-310-onemed1a-1
+            -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+            -Dsonar.sources=onemed1a-backend/src/main/java,onemed1a-frontend/src
+            -Dsonar.tests=onemed1a-backend/src/test/java,onemed1a-frontend/src
+            -Dsonar.java.binaries=onemed1a-backend/target/classes
+            -Dsonar.javascript.lcov.reportPaths=onemed1a-frontend/coverage/lcov.info
+            -Dsonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Description of changes
Added SonarCloud CI integration: a GitHub Actions workflow that builds the backend and frontend and runs the SonarCloud scanner, plus the necessary configuration to pick up both modules. This enables automated static analysis and PR decoration, but requires a SonarCloud project and a repository secret named SONAR_TOKEN to be created before scans will succeed. I kept the scan configuration conservative (Java 21 / Node build) and left coverage integration as an optional follow-up to enable line-level coverage reporting. Please review the workflow and confirm the SonarCloud project key/org and secret so I can finalise coverage reporting in a follow-up.

## Linked issue(s)

Closes #128 

## Checklist

- [ ] I rebased onto `upstream/main` before pushing
- [ ] No secrets or .env files committed
