### PR TITLE
Update spring-boot version

### DIFF
--- a/onemed1a-backend/pom.xml
+++ b/onemed1a-backend/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.6</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
## Description of changes

Upgraded Spring Boot from 3.5.4 to 3.5.6 to fix high-severity vulnerabilities in transitive dependencies, including Tomcat embedded (CVE-2025-48989) and Spring Beans/Core issues.

## Linked issue(s)

Closes #135 

## Checklist

- [ ] I rebased onto `upstream/main` before pushing
- [ ] No secrets or .env files committed
